### PR TITLE
Fix branch trigger in CI configuration

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: Docs Publish
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   deploy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 jobs:
   docs:
     name: docs


### PR DESCRIPTION
In #1 we added a ci configuration to build and publish docs, however
those jobs are never triggered because they were using the wrong primary
development branch for the repository; the branch is main, not master.
This commit fixes that oversight so CI should actually be triggered now.