### PR TITLE
Remove unecessary gettext job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,25 +26,3 @@ jobs:
         QISKIT_DOCS_BUILD_TUTORIALS: 'always'
       run: |
         tools/deploy_documentation.sh
-  deploy-translatable-strings:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.8'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -U virtualenv setuptools wheel tox
-        sudo apt-get install graphviz pandoc
-    - name: Build and publish
-      env:
-        encrypted_deploy_po_branch_key: ${{ secrets.encrypted_deploy_po_branch_key }}
-        encrypted_deploy_po_branch_iv: ${{ secrets.encrypted_deploy_po_branch_iv }}
-        QISKIT_DOCS_BUILD_TUTORIALS: 'always'
-      run: |
-        tools/deploy_translatable_strings.sh


### PR DESCRIPTION
This commit removes an unecessary CI job that is used to run sphinx
gettext to extract the translatable strings from the documentation and
push them to the qiskit-community/qiskit-translations repo. This was
copied from qiskit/qiskit but isn't needed here, and doesn't actually
work.