### PR TITLE
Add mthree to other docs build lists

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -3,3 +3,4 @@ ionq/**
 aqt/**
 honeywell/**
 qiskit_runtime/**
+mthree/**


### PR DESCRIPTION
The Qiskit-Partners/mthree repo will soon be publishing docs and to
avoid root partners docs from deleting those we need to add it to the
other builds list so they're excluded from the rclone sync. This commit
makes this change.