### PR TITLE
Remove qiskit_runtime since the docs here are outdated

### DIFF
--- a/tools/other-builds.txt
+++ b/tools/other-builds.txt
@@ -2,6 +2,5 @@ ibm/**
 ionq/**
 aqt/**
 honeywell/**
-qiskit_runtime/**
 mthree/**
 qiskit_ibm_runtime/**


### PR DESCRIPTION
Outdated docs are causing confusion. It is better to have broken links in my opinion. Hoping this would delete the folder on rsync.