### PR TITLE
Remove mthree from partners in favor of ecosystem subpage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -85,25 +85,6 @@ Runtime systems
   :link-badge:`https://github.com/qiskit/qiskit-ibm-runtime,"Github",cls=badge-success text-white`
 
 
-Software
-########
-
-.. panels::
-  :column: col-xl-4 col-lg-4 col-md-4 col-sm-4 col-xs-4 p-2
-
-  Matrix-free measurement mitigation (M3)
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-  .. image:: images/m3_visual.png
-      :scale: 30 %
-      :align: center
-      :target: https://qiskit.org/documentation/partners/mthree
-
-
-  ++++++
-  :link-badge:`https://qiskit.org/documentation/partners/mthree,"Docs",cls=badge-primary text-white`
-  :link-badge:`https://github.com/Qiskit-Partners/mthree,"Github",cls=badge-success text-white`
-
-
 .. Hiding - Indices and tables
    :ref:`genindex`
    :ref:`modindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,7 +2,7 @@
 Qiskit Partners
 ###############
 
-A collection of quantum hardware and software partners that extend and compliment the Qiskit ecosystem.
+A collection of quantum hardware partners that connect to Qiskit.
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
The https://qiskit.org/documentation/partners/#software includes non-hardware partners. That should be currently covered by https://qiskit.org/ecosystem/