### PR TITLE
broken markup: #18 follow up

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Quantum (Hardware) Service Providers
 
   ++++++
   :link-badge:`https://www.ibm.com/quantum/systems,"Website",cls=badge-dark text-white`
-  :link-badge: `https://quantum-computing.ibm.com/services/resources, "Compute resources",cls=badge-dark text-white` 
+  :link-badge:`https://quantum-computing.ibm.com/services/resources, "Compute resources",cls=badge-dark text-white` 
   :link-badge:`https://quantum-computing.ibm.com/services/resources/docs/resources/manage/systems/,"Docs",cls=badge-primary text-white`
   :link-badge:`https://github.com/Qiskit/qiskit-ibm-provider,"Github",cls=badge-success text-white`
 


### PR DESCRIPTION
I accidentally broke the IBM Quantum tile in #18. My bad, it was obvious even from the GH highlighting.

from
![Screenshot 2022-10-20 at 13 25 54](https://user-images.githubusercontent.com/766693/196936240-5d248b16-29b6-4095-a2f5-3f254f476b74.png)
to
![Screenshot 2022-10-20 at 13 23 33](https://user-images.githubusercontent.com/766693/196935944-16669a6a-b55f-436d-8831-7272c554d664.png)